### PR TITLE
Add `files` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,57 @@ var nobodyLikesTodosAnyway = new Funnel('src', {
 
 module.exports = nobodyLikesTodosAnyway;
 ```
+
+----
+
+`files` *{Array of Strings}*
+
+One or more relative file paths. Files within the tree whose relative paths match
+will be copied (with the location inside their parent directories
+preserved) to the `destDir`.
+
+Default: `[]`.
+
+If your project has the following file structure
+
+```shell
+.
+├── Brocfile.js
+└── src/
+    ├── css/
+    │   ├── reset.css
+    │   └── todos.css
+    ├── icons/
+    │   ├── check-mark.png
+    │   └── logo.jpg
+    └── javascript/
+        ├── app.js
+        └── todo.js
+```
+
+You can select a specific list of files copy those subtrees to a
+new location, preserving their location within parent directories:
+
+```javascript
+var Funnel = require('broccoli-funnel');
+
+// finds these specific files and moves them to the destDir
+var someFiles = new Funnel('src', {
+  files: ['css/reset.css', 'icons/check-mark.png']
+});
+
+/*
+  someFiles is equivalent to the tree:
+  .
+  ├── css
+  │   └── reset.css
+  └── icons
+      └── check-mark.png
+*/
+
+module.exports = someFiles;
+```
+
 ----
 
 `getDestinationPath` *{Function}*

--- a/index.js
+++ b/index.js
@@ -35,6 +35,10 @@ function Funnel(inputTree, options) {
 
   this.setupDestPaths();
 
+  if (this.files && !Array.isArray(this.files)) {
+    throw new Error('Invalid files option, it must be an array.');
+  }
+
   if (this.include && !Array.isArray(this.include)) {
     throw new Error('Invalid include option, it must be an array.');
   }
@@ -59,7 +63,7 @@ Funnel.prototype.setupDestPaths = function() {
 };
 
 Funnel.prototype.shouldLinkRoots = function() {
-  return !this.include && !this.exclude && !this.getDestinationPath;
+  return !this.files && !this.include && !this.exclude && !this.getDestinationPath;
 };
 
 Funnel.prototype.read = function(readTree) {
@@ -139,6 +143,11 @@ Funnel.prototype.includeFile = function(relativePath) {
   }
 
   var i, l;
+
+  // Check for specific files listing
+  if (this.files) {
+    return includeFileCache[relativePath] = this.files.indexOf(relativePath) > -1;
+  }
 
   // Check exclude patterns
   if (this.exclude) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -66,6 +66,35 @@ describe('broccoli-funnel', function(){
   });
 
   describe('with filtering options', function() {
+
+    describe('filtering with `files`', function() {
+      it('can take a list of files', function() {
+        var inputPath = path.join(fixturePath, 'dir1');
+        var tree = new Funnel(inputPath, {
+          files: [
+            'subdir1/subsubdir1/foo.png',
+            'subdir2/bar.css'
+          ]
+        });
+
+        builder = new broccoli.Builder(tree);
+        return builder.build()
+        .then(function(results) {
+          var outputPath = results.directory;
+
+          var expected = [
+            'subdir1/',
+            'subdir1/subsubdir1/',
+            'subdir1/subsubdir1/foo.png',
+            'subdir2/',
+            'subdir2/bar.css'
+          ];
+
+          expect(walkSync(outputPath)).to.eql(expected);
+        });
+      });
+    });
+
     describe('include filtering', function() {
       it('can take a pattern', function() {
         var inputPath = path.join(fixturePath, 'dir1');


### PR DESCRIPTION
This allows `broccoli-funnel` to be mostly a drop in replacement for `broccoli-static-compiler` when you have a specific list of files.

/cc @trek can you review the README updates here?
