### PR TITLE
Don't require "new"

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function makeDictionary() {
 }
 
 function Funnel(inputTree, options) {
-  if (!(this instanceof Funnel)) { return new Funnel(inputTree, options); }
+  if (!(this instanceof Funnel)) { console.error(new Error('You must use \'new Funnel\' to instantiate a broccoli-funnel item.')); }
 
   this.inputTree = inputTree;
 


### PR DESCRIPTION
Broccoli plugins typically call "new" on themselves when called as a
plain function.

This patch lets you just call `funnel(inputTree, options);` in your Brocfile and it will just work.

Thanks for broccoli-funnel, it's a great alternative to the default static compiler plugin! 
