### PR TITLE
Make compatible with legacy broccoli versions.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var walkSync = require('walk-sync');
 var Minimatch = require('minimatch').Minimatch;
 var CoreObject = require('core-object');
 var symlinkOrCopy = require('symlink-or-copy');
+var readAPICompat = require('broccoli-read-compat');
 
 
 function makeDictionary() {
@@ -212,5 +213,7 @@ Funnel.prototype._copy = function(sourcePath, destPath) {
 
   symlinkOrCopy.sync(sourcePath, destPath);
 };
+
+readAPICompat.wrapFactory(Funnel);
 
 module.exports = Funnel;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "javascript"
   ],
   "dependencies": {
+    "broccoli-read-compat": "^0.1.2",
     "core-object": "0.0.2",
     "minimatch": "^2.0.1",
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
This is using the new [broccoli-read-compat](https://github.com/broccolijs/broccoli-read-compat) package to make it possible for individual plugins to use the new syntax, while still supporting older non-`rebuild` aware Broccoli versions.