### PR TITLE
perf: don't walk the input tree if all files are explicitly defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,14 @@ Funnel.prototype.rebuild = function() {
 };
 
 Funnel.prototype.processFilters = function(inputPath) {
-  var files = walkSync(inputPath);
+  var files;
+
+  if (this.files && !this.exclude && !this.include) {
+    files = this.files.slice(0); //clone to be compatible with walkSync
+  } else {
+    files = walkSync(inputPath);
+  }
+
   var relativePath, destRelativePath, fullInputPath, fullOutputPath;
 
   for (var i = 0, l = files.length; i < l; i++) {


### PR DESCRIPTION
If we have a big input tree and only need to pick explicitly defined files,
it should not be necessary to walk the entire input tree. Instead, take the
 property and use that as the complete list of input files.

I didn't include any tests since only internal implementation has changed
and it's not clear how could I mock out the walkSync function to verify that
it wasn't called.