### PR TITLE
Do not use CoreObject

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ var path = require('path');
 var mkdirp = require('mkdirp');
 var walkSync = require('walk-sync');
 var Minimatch = require('minimatch').Minimatch;
-var CoreObject = require('core-object');
 var symlinkOrCopy = require('symlink-or-copy');
 var readAPICompat = require('broccoli-read-compat');
 
@@ -43,9 +42,6 @@ function Funnel(inputTree, options) {
 
   this._instantiatedStack = (new Error()).stack;
 }
-
-Funnel.__proto__ = CoreObject;
-Funnel.prototype.constructor = Funnel;
 
 Funnel.prototype._setupFilter = function(type) {
   if (!this[type]) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   ],
   "dependencies": {
     "broccoli-read-compat": "^0.1.2",
-    "core-object": "0.0.2",
     "minimatch": "^2.0.1",
     "mkdirp": "^0.5.0",
     "symlink-or-copy": "^1.0.0",


### PR DESCRIPTION
I'd like to derive from broccoli-plugin, but at the moment we're setting the `__proto__` to `CoreObject`. (I'm a bit confused as to what this actually does - it looks like we're not subclassing, but using CoreObject as a meta class of some sort...) In any case, my impression is that this is unused, so we can simply get rid of it.