### PR TITLE
when includes are matchable, use them while walking.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "minimatch": "^2.0.1",
     "mkdirp": "^0.5.0",
     "symlink-or-copy": "^1.0.0",
-    "walk-sync": "^0.1.3"
+    "walk-sync-matcher": "^0.2.0"
   },
   "devDependencies": {
     "broccoli": "^0.15.0",

--- a/tests/index.js
+++ b/tests/index.js
@@ -4,7 +4,7 @@ var fs = require('fs');
 var path = require('path');
 var RSVP = require('rsvp');
 var expect = require('expect.js');
-var walkSync = require('walk-sync');
+var walkSync = require('walk-sync-matcher');
 var broccoli = require('broccoli');
 var rimraf = RSVP.denodeify(require('rimraf'));
 


### PR DESCRIPTION
- [x] needs fork of walk-sync
- [x] cleanup etc.

I want to deprecate regexp, since globs are easier to optimize. Thoughts @rwjblue ?