### PR TITLE
Dynamic files filtering via function

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var path = require('path');
 var mkdirp = require('mkdirp');
 var walkSync = require('walk-sync-matcher');
 var Minimatch = require('minimatch').Minimatch;
+var arrayEqual = require('array-equal');
 var Plugin = require('broccoli-plugin');
 var symlinkOrCopy = require('symlink-or-copy');
 var debug = require('debug');
@@ -35,8 +36,13 @@ function Funnel(inputNode, options) {
 
   this.destDir = this.destDir || '/';
 
-  if (this.files && !Array.isArray(this.files)) {
-    throw new Error('Invalid files option, it must be an array.');
+  if (this.files && typeof this.files === 'function') {
+    // Save dynamic files func as a different variable and let the rest of the code
+    // still assume that this.files is always an array.
+    this._dynamicFilesFunc = this.files;
+    delete this.files;
+  } else if (this.files && !Array.isArray(this.files)) {
+    throw new Error('Invalid files option, it must be an array or function (that returns an array).');
   }
 
   this._setupFilter('include');
@@ -103,6 +109,16 @@ Funnel.prototype.build = function() {
   var inputPath = this.inputPaths[0];
   if (this.srcDir) {
     inputPath = path.join(inputPath, this.srcDir);
+  }
+
+  if (this._dynamicFilesFunc) {
+    this.lastFiles = this.files;
+    this.files = this._dynamicFilesFunc() || [];
+
+    // Blow away the include cache if the list of files is new
+    if (this.lastFiles !== undefined && !arrayEqual(this.lastFiles, this.files)) {
+      this._includeFileCache = makeDictionary();
+    }
   }
 
   var linkedRoots = false;

--- a/index.js
+++ b/index.js
@@ -45,6 +45,10 @@ function Funnel(inputNode, options) {
     throw new Error('Invalid files option, it must be an array or function (that returns an array).');
   }
 
+  if ((this.files || this._dynamicFilesFunc) && (this.include || this.exclude)) {
+    throw new Error('Cannot pass files option (array or function) and a include/exlude filter. You can only have one or the other');
+  }
+
   this._setupFilter('include');
   this._setupFilter('exclude');
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "javascript"
   ],
   "dependencies": {
+    "array-equal": "^1.0.0",
     "broccoli-plugin": "^1.0.0",
     "debug": "^2.2.0",
     "minimatch": "^2.0.1",

--- a/tests/index.js
+++ b/tests/index.js
@@ -331,6 +331,143 @@ describe('broccoli-funnel', function(){
       });
     });
 
+    describe('filtering with a `files` function', function() {
+      it('can take files as a function', function() {
+        var inputPath = path.join(fixturePath, 'dir1');
+        var filesCounter = 0;
+        var filesByCounter = [
+          [
+            'subdir1/subsubdir1/foo.png',
+            'subdir2/bar.css'
+          ],
+          [ 'subdir1/subsubdir1/foo.png' ],
+          [],
+          ['subdir1/subsubdir2/some.js']
+        ];
+
+        var tree = new Funnel(inputPath, {
+          files: function() {
+            return filesByCounter[filesCounter++];
+          }
+        });
+
+        builder = new broccoli.Builder(tree);
+
+        return builder.build()
+        .then(function(results) {
+          var outputPath = results.directory;
+
+          var expected = [
+            'subdir1/',
+            'subdir1/subsubdir1/',
+            'subdir1/subsubdir1/foo.png',
+            'subdir2/',
+            'subdir2/bar.css'
+          ];
+
+          expect(walkSync(outputPath)).to.eql(expected);
+
+          // Build again
+          return builder.build();
+        })
+        .then(function(results) {
+          var outputPath = results.directory;
+
+          var expected = [
+            'subdir1/',
+            'subdir1/subsubdir1/',
+            'subdir1/subsubdir1/foo.png',
+          ];
+
+          expect(walkSync(outputPath)).to.eql(expected);
+
+          // Build again
+          return builder.build();
+        })
+        .then(function(results) {
+          var outputPath = results.directory;
+
+          var expected = [];
+
+          expect(walkSync(outputPath)).to.eql(expected);
+
+          // Build again
+          return builder.build();
+        })
+        .then(function(results) {
+          var outputPath = results.directory;
+
+          var expected = [
+            'subdir1/',
+            'subdir1/subsubdir2/',
+            'subdir1/subsubdir2/some.js'
+          ];
+
+          expect(walkSync(outputPath)).to.eql(expected);
+        });
+      });
+
+      it('can take files as a function with exclude (includeCache needs to be cleared)', function() {
+        var inputPath = path.join(fixturePath, 'dir1');
+        var filesCounter = 0;
+        var filesByCounter = [
+          [],
+          [ 'subdir1/subsubdir1/foo.png' ],
+          [
+            'subdir1/subsubdir1/foo.png',
+            'subdir2/bar.css'
+          ]
+        ];
+
+        var tree = new Funnel(inputPath, {
+          files: function() {
+            return filesByCounter[filesCounter++];
+          }
+        });
+
+        builder = new broccoli.Builder(tree);
+
+        return builder.build()
+        .then(function(results) {
+          var outputPath = results.directory;
+
+          var expected = [];
+
+          expect(walkSync(outputPath)).to.eql(expected);
+
+          // Build again
+          return builder.build();
+        })
+        .then(function(results) {
+          var outputPath = results.directory;
+
+          var expected = [
+            'subdir1/',
+            'subdir1/subsubdir1/',
+            'subdir1/subsubdir1/foo.png',
+          ];
+
+          expect(walkSync(outputPath)).to.eql(expected);
+
+          // Build again
+          return builder.build();
+        })
+        .then(function(results) {
+          var outputPath = results.directory;
+
+          var expected = [
+            'subdir1/',
+            'subdir1/subsubdir1/',
+            'subdir1/subsubdir1/foo.png',
+            'subdir2/',
+            'subdir2/bar.css'
+          ];
+
+          expect(walkSync(outputPath)).to.eql(expected);
+        });
+      });
+    });
+
     describe('include filtering', function() {
       function testAllIncludeMatchers(glob, regexp, func, expected) {
         it('can take a glob string', function() {

--- a/tests/index.js
+++ b/tests/index.js
@@ -331,6 +331,30 @@ describe('broccoli-funnel', function(){
       });
     });
 
+    describe('`files` is incompatible with filters', function() {
+      it('so error if `files` and `include` are set', function() {
+        var inputPath = path.join(fixturePath, 'dir1');
+
+        expect(function() {
+          new Funnel(inputPath, {
+            files: ['anything'],
+            include: ['*.txt']
+          });
+        }).to.throwException('Cannot pass files option (array or function) and a include/exlude filter. You can only have one or the other');
+      });
+
+      it('so error if `files` and `exclude` are set', function() {
+        var inputPath = path.join(fixturePath, 'dir1');
+
+        expect(function() {
+          new Funnel(inputPath, {
+            files: function() { return ['anything']; },
+            exclude: ['*.md']
+          });
+        }).to.throwException('Cannot pass files option (array or function) and a include/exlude filter. You can only have one or the other');
+      });
+    });
+
     describe('filtering with a `files` function', function() {
       it('can take files as a function', function() {
         var inputPath = path.join(fixturePath, 'dir1');


### PR DESCRIPTION
Allows the `files` option to be a function that is run every build.

This enables dynamic filtering of files (in an exact, performant way). Also, it  enables `files` to be set lazily/late, helpful in the situation where you don’t yet have the list of files at Brocfile definition time (need some of the build to have finished, an async fetch to run, etc).

Context: https://github.com/broccolijs/broccoli-funnel/issues/25

ps: Adds an early error to prevent usage of both `files` and `include`/`exclude`. That is a slightly backwards incompatible change, but prevents unexpected behavior (because `include`/`exclude` filters are currently never checked if `files` is set).