### PR TITLE
Bump heimdalljs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "debug": "^2.2.0",
     "fast-ordered-set": "^1.0.0",
     "fs-tree-diff": "^0.5.1",
-    "heimdalljs": "^0.1.2",
+    "heimdalljs": "^0.1.4",
     "minimatch": "^3.0.0",
     "mkdirp": "^0.5.0",
     "path-posix": "^1.0.0",


### PR DESCRIPTION
- [ ] blocked on heimdall 0.1.4 (see https://github.com/heimdalljs/heimdalljs-lib/pull/3)
- [ ] run tests after heimdall 0.1.4 released