### PR TITLE
Update exists-sync. Add relative path test.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "blank-object": "^1.0.1",
     "broccoli-plugin": "^1.0.0",
     "debug": "^2.2.0",
-    "exists-sync": "0.0.3",
+    "exists-sync": "0.0.4",
     "fast-ordered-set": "^1.0.0",
     "fs-tree-diff": "^0.5.3",
     "heimdalljs": "^0.2.0",

--- a/tests/index.js
+++ b/tests/index.js
@@ -148,6 +148,23 @@ describe('broccoli-funnel', function(){
         });
     });
 
+    it('properly supports relative path input node', function() {
+      var assertions = 0;
+
+      var node = new Funnel('../broccoli-funnel', {
+        destDir: 'foo'
+      });
+
+      builder = new broccoli.Builder(node);
+      return builder.build()
+        .catch(function(error) {
+          assertions++;
+        })
+        .then(function() {
+          expect(assertions).to.equal(0, 'Build did not throw an error, relative path traversal worked.');
+        });
+    });
+
     it('throws error on unspecified allowEmpty', function() {
       var assertions = 0;
       var inputPath = FIXTURE_INPUT + '/dir1';


### PR DESCRIPTION
Closes #81. Stemming from the adoption of `exists-sync`.

Will track upstream fix at https://github.com/ember-cli/exists-sync/issues/4.