### PR TITLE
Pins Heimdalljs To Last Known Good Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "exists-sync": "0.0.4",
     "fast-ordered-set": "^1.0.0",
     "fs-tree-diff": "^0.5.3",
-    "heimdalljs": "^0.2.0",
+    "heimdalljs": "0.2.1",
     "minimatch": "^3.0.0",
     "mkdirp": "^0.5.0",
     "path-posix": "^1.0.0",


### PR DESCRIPTION
Fixes: https://github.com/broccolijs/broccoli-funnel/issues/83 by pinning Heimdalljs to last known working version.

I realize this isn't an actual fix, but right now anyone building with `ember-cli` who isn't vendoring their dependencies is broken right now.