### PR TITLE
Instruct the builder that we don't need a cache dir.

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,12 +51,15 @@ function isNotAPattern(pattern) {
 
 Funnel.prototype = Object.create(Plugin.prototype);
 Funnel.prototype.constructor = Funnel;
-function Funnel(inputNode, options) {
-  if (!(this instanceof Funnel)) { return new Funnel(inputNode, options); }
+function Funnel(inputNode, _options) {
+  if (!(this instanceof Funnel)) { return new Funnel(inputNode, _options); }
 
-  Plugin.call(this, [inputNode], options);
-
-  this._persistentOutput = true;
+  var options = _options || {};
+  Plugin.call(this, [inputNode], {
+    annotation: options.annotation,
+    persistentOutput: true,
+    needsCache: false
+  });
 
   this._includeFileCache = makeDictionary();
   this._destinationPathCache = makeDictionary();

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "array-equal": "^1.0.0",
     "blank-object": "^1.0.1",
-    "broccoli-plugin": "^1.0.0",
+    "broccoli-plugin": "^1.3.0",
     "debug": "^2.2.0",
     "exists-sync": "0.0.4",
     "fast-ordered-set": "^1.0.0",


### PR DESCRIPTION
Upcoming changes to broccoli itself will expose this as configuration. broccoli-funnel does not utilize the provided cache directory, so this just tells broccoli to avoid the extraneous work.