### PR TITLE
Major version bump :tada:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "broccoli-funnel",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Broccoli plugin that allows you to filter files selected from an input node down based on regular expressions.",
   "main": "index.js",
   "author": "Robert Jackson",


### PR DESCRIPTION
We dropped support for `node@0.12`.

cc @rwjblue @stefanpenner 
