### PR TITLE
Fix exclude option docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ module.exports = todoRelatedFiles;
 
 ----
 
-`exclude` *{Array of Glob Strings|Glob String|Function}*
+`exclude` *{Array of Glob Strings|Function}*
 
 One or more matcher expression (regular expression, glob string, or function). Files within the node whose names match this
 expression will _not_ be copied to the `destDir` if they otherwise would have


### PR DESCRIPTION
A plain string is not allowed - single strings must still be wrapped in an array.