### PR TITLE
Handle empty input nodes when `include` or `exclude` are set.

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,6 +198,8 @@ Funnel.prototype.build = function() {
     }
   }
 
+  let inputPathExists = fs.existsSync(inputPath);
+
   let linkedRoots = false;
   if (this.shouldLinkRoots()) {
     linkedRoots = true;
@@ -215,8 +217,6 @@ Funnel.prototype.build = function() {
      * all scenarios made it possible for initial builds to succeed without
      * specifying `this.allowEmpty`.
      */
-
-    let inputPathExists = fs.existsSync(inputPath);
 
     // This is specifically looking for broken symlinks.
     let outputPathExists = fs.existsSync(this.outputPath);
@@ -255,8 +255,12 @@ Funnel.prototype.build = function() {
     /*eslint-enable no-lonely-if*/
 
     this._isRebuild = true;
-  } else {
+  } else if (inputPathExists) {
     this.processFilters(inputPath);
+  } else if (!this.allowEmpty) {
+    throw new Error(`You specified a \`"srcDir": ${this.srcDir}\` which does not exist and did not specify \`"allowEmpty": true\`.`);
+  } else { // !inputPathExists && this.allowEmpty
+    // Do nothing (?)
   }
 
   this._debug('build, %o', {

--- a/index.js
+++ b/index.js
@@ -260,7 +260,9 @@ Funnel.prototype.build = function() {
   } else if (!this.allowEmpty) {
     throw new Error(`You specified a \`"srcDir": ${this.srcDir}\` which does not exist and did not specify \`"allowEmpty": true\`.`);
   } else { // !inputPathExists && this.allowEmpty
-    // Do nothing (?)
+    // Just make an empty folder so that any downstream consumers who don't know
+    // to ignore this on `allowEmpty` don't get trolled.
+    mkdirp(this.destPath);
   }
 
   this._debug('build, %o', {

--- a/tests/index.js
+++ b/tests/index.js
@@ -375,14 +375,14 @@ describe('broccoli-funnel', function() {
         allowEmpty: true,
       });
 
-       let expected = ['some-place/'];
+      let expected = ['some-place/'];
 
-       builder = new broccoli.Builder(node);
+      builder = new broccoli.Builder(node);
       return builder.build()
         .then(results => {
           let outputPath = results.directory;
 
-           expect(walkSync(outputPath)).to.eql(expected);
+          expect(walkSync(outputPath)).to.eql(expected);
         })
         .then(() => builder.build())
         .then(results => {

--- a/tests/index.js
+++ b/tests/index.js
@@ -365,6 +365,39 @@ describe('broccoli-funnel', function() {
           expect(walkSync(outputPath)).to.eql(expected);
         });
     });
+
+    it('creates nested output path when input node at a missing nested source', function() {
+      let inputPath = `${FIXTURE_INPUT}/dir1`;
+      let node = new Funnel(inputPath, {
+        include: ['*'],
+        srcDir: 'subdir3',
+        destDir: 'some-place',
+        allowEmpty: true,
+      });
+
+       let expected = ['some-place/'];
+
+       builder = new broccoli.Builder(node);
+      return builder.build()
+        .then(results => {
+          let outputPath = results.directory;
+
+           expect(walkSync(outputPath)).to.eql(expected);
+        })
+        .then(() => builder.build())
+        .then(results => {
+          let outputPath = results.directory;
+
+          expect(walkSync(outputPath)).to.eql(expected);
+
+          return builder.build();
+        })
+        .then(results => {
+          let outputPath = results.directory;
+
+          expect(walkSync(outputPath)).to.eql(expected);
+        });
+    });
   });
 
   describe('without filtering options', function() {

--- a/tests/index.js
+++ b/tests/index.js
@@ -333,11 +333,36 @@ describe('broccoli-funnel', function() {
       builder = new broccoli.Builder(node);
       return builder.build()
         .catch(error => {
-          expect(error.stack.toString()).to.contain('You specified a `"srcDir": subdir3` which does not exist and did not specify `"allowEmpty": true`.');
+          expect(error.message).to.contain('You specified a `"srcDir": subdir3` which does not exist and did not specify `"allowEmpty": true`.');
           assertions++;
         })
         .then(() => {
           expect(assertions).to.equal(1, 'Build threw an error.');
+        });
+    });
+
+    it('does not error with input node at a missing nested source', function() {
+      let inputPath = `${FIXTURE_INPUT}/dir1`;
+      let node = new Funnel(inputPath, {
+        include: ['*'],
+        srcDir: 'subdir3',
+        allowEmpty: true,
+      });
+
+      let expected = [];
+
+      builder = new broccoli.Builder(node);
+      return builder.build()
+        .then(results => {
+          let outputPath = results.directory;
+
+          expect(walkSync(outputPath)).to.eql(expected);
+        })
+        .then(() => builder.build())
+        .then(results => {
+          let outputPath = results.directory;
+
+          expect(walkSync(outputPath)).to.eql(expected);
         });
     });
   });

--- a/tests/index.js
+++ b/tests/index.js
@@ -320,6 +320,26 @@ describe('broccoli-funnel', function() {
 
       expect(node._matchedWalk).to.eql(true);
     });
+
+    it('throws error on unspecified allowEmpty', function() {
+      let assertions = 0;
+      let inputPath = `${FIXTURE_INPUT}/dir1`;
+      let node = new Funnel(inputPath, {
+        include: ['*'],
+        srcDir: 'subdir3',
+        destDir: 'subdir3',
+      });
+
+      builder = new broccoli.Builder(node);
+      return builder.build()
+        .catch(error => {
+          expect(error.stack.toString()).to.contain('You specified a `"srcDir": subdir3` which does not exist and did not specify `"allowEmpty": true`.');
+          assertions++;
+        })
+        .then(() => {
+          expect(assertions).to.equal(1, 'Build threw an error.');
+        });
+    });
   });
 
   describe('without filtering options', function() {


### PR DESCRIPTION
Note that this implementation is a bit of a mess at this point. I'm happy to try to do some follow-on refactoring, but this solves the actual bug noted in #105 and identified while trying to fix aexmachina/ember-cli-sass#204.

Fixes #105.