### PR TITLE
Fixing windows test with a temporary workaround

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const debug = require('debug');
 const FSTree = require('fs-tree-diff');
 const BlankObject = require('blank-object');
 const heimdall = require('heimdalljs');
+const fs = require('fs');
 
 function ApplyPatchesSchema() {
   this.mkdir = 0;
@@ -40,6 +41,19 @@ function isNotAPattern(pattern) {
     }
   }
 
+  return true;
+}
+function existsSync(path) {
+  let error = {};
+  try {
+    fs.accessSync(path);
+    fs.statSync(path);
+  } catch (err) {
+    error = err;
+  }
+  if (error.errno && error.errno !== 0) {
+    return false;
+  }
   return true;
 }
 
@@ -208,6 +222,12 @@ class Funnel extends Plugin {
 
       // This is specifically looking for broken symlinks.
       let outputPathExists = this.output.existsSync('./');
+      // We need to keep this till node 10,12 get fix for windows broken symlink issue.
+      // https://github.com/nodejs/node/issues/30538
+      let isWin = process.platform === 'win32';
+      if (isWin) {
+        outputPathExists = existsSync(this.outputPath);
+      }
 
       // Doesn't count as a rebuild if there's not an existing outputPath.
       this._isRebuild = this._isRebuild && outputPathExists;


### PR DESCRIPTION
> Perhaps exists should just check both access and stat on Windows...

Code tries to do as mentioned in the [comment](https://github.com/nodejs/node/issues/30538#issuecomment-555661342) and the fix provided into nodeJS https://github.com/nodejs/node/commit/366a45be2a084f943cee38602eef821ad4a94286