### PR TITLE
Fix test to actually check generated files with destDir

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -255,10 +255,6 @@ describe('broccoli-funnel', function() {
       let node = new Funnel(inputPath, {
         include: [/.png$/, /.js$/],
         destDir: 'foo',
-
-        processFile() {
-          /* do nothing */
-        },
       });
 
       output = createBuilder(node);
@@ -269,7 +265,9 @@ describe('broccoli-funnel', function() {
         'foo/',
         'foo/subdir1/',
         'foo/subdir1/subsubdir1/',
+        'foo/subdir1/subsubdir1/foo.png',
         'foo/subdir1/subsubdir2/',
+        'foo/subdir1/subsubdir2/some.js',
       ]);
     });
 


### PR DESCRIPTION
This PR aims to improve an existing test to actually test file generation when destDir is supplied, as the test name indicates: "is responsible for generating files in the destDir".