### PR TITLE
fix srcDir + filtering

### DIFF
--- a/index.js
+++ b/index.js
@@ -326,9 +326,9 @@ class Funnel extends Plugin {
     } else {
 
       if (this._matchedWalk) {
-        entries = this.input.entries('.', { globs: this.include, ignore: this.exclude });
+        entries = this.input.entries(this.srcDir || './', { globs: this.include, ignore: this.exclude });
       } else {
-        entries = this.input.entries('.');
+        entries = this.input.entries(this.srcDir || './');
       }
 
       entries = this._processEntries(entries);

--- a/tests/index.js
+++ b/tests/index.js
@@ -451,6 +451,25 @@ describe('broccoli-funnel', function() {
       expect(walkSync(outputPath)).to.eql(walkSync(restrictedInputPath));
     });
 
+    it('supports "srcDir", "destDir", and "exclude" together', async function() {
+      let inputPath = `${FIXTURE_INPUT}/dir1`;
+      let node = new Funnel(inputPath, {
+        srcDir: 'subdir1',
+        destDir: 'myDest',
+        exclude: ['whatever'],
+      });
+
+      output = createBuilder(node);
+      await output.build();
+      let outputPath = output.path();
+      let restrictedInputPath = `${inputPath}/subdir1`;
+
+      expect(walkSync(`${outputPath}/myDest`)).to.eql(walkSync(restrictedInputPath));
+      await output.build();
+      expect(walkSync(`${outputPath}/myDest`)).to.eql(walkSync(restrictedInputPath));
+    });
+
+
     it('matches *.css', async function() {
       let inputPath = `${FIXTURE_INPUT}/dir1/subdir2`;
       let node = new Funnel(inputPath, {


### PR DESCRIPTION
PR https://github.com/broccolijs/broccoli-funnel/pull/120 broke the case when you have both `srcDir` and some filtering options like `exclude`. The included test demonstrates the bug. It crashes during `processFile` because the `sourcePath` doesn't exist.

This PR fixes the bug by restoring the correct relative paths as inputs to `walkSync`.