### PR TITLE
Stop gathering instantiation stack manually.

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,8 +104,6 @@ class Funnel extends Plugin {
     this._setupFilter('exclude');
 
     this._matchedWalk = this.canMatchWalk();
-
-    this._instantiatedStack = (new Error()).stack;
     this._buildStart = undefined;
   }
 


### PR DESCRIPTION
This was added waaaaaay back in 46e1e23 (2014), long before the newer `broccoli-plugin` APIs (around Broccoli@1) started creating an instantiation stack to be used for error handling across the board.

Now that we extend from broccoli-plugin directly, we no longer have to do this manually. Additionally, the code in broccoli-plugin is authored such that it avoids touching the `.stack` property unless it is actually needed (forcing V8 to create the stack is costly).

Thanks to @krisselden for pointing this out.
