### PR TITLE
Allow subclasses to add additional input nodes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,8 +50,9 @@ function existsSync(path) {
 }
 
 class Funnel extends Plugin {
-  constructor(inputNode, options = {}) {
-    super([inputNode], {
+  constructor(inputs, options = {}) {
+    let inputNodes = Array.isArray(inputs) ? inputs : [inputs];
+    super(inputNodes, {
       annotation: options.annotation,
       persistentOutput: true,
       needsCache: false,


### PR DESCRIPTION
Subclassing broccoli-funnel has become somewhat common (e.g. Embroider and ember-css-modules both do it). This adds a basic test to confirm that it generally works.

Additionally, this adds the ability for the subclass to add additional nodes to be considered as part of the broccoli tree graph. This ensures that if you happen to subclass and need to read from another tree to know where to write, you can add that other tree to your inputs and be *guaranteed* that they will have been built before you are called.  Without this change, it _might_ seem to work **sometimes** but it is absolutely not guaranteed to work.
