### PR TITLE
Ensure adding additional trees does not affect include/exclude results.

### DIFF
--- a/index.js
+++ b/index.js
@@ -192,7 +192,7 @@ class Funnel extends Plugin {
       }
     }
 
-    let inputPathExists = this.input.existsSync(this.srcDir || './');
+    let inputPathExists = this.input.at(0).fs.existsSync(this.srcDir || './');
 
     let linkedRoots = false;
     if (this.shouldLinkRoots()) {
@@ -317,9 +317,9 @@ class Funnel extends Plugin {
     } else {
 
       if (this._matchedWalk) {
-        entries = this.input.entries(this.srcDir || './', { globs: this.include, ignore: this.exclude });
+        entries = this.input.at(0).entries(this.srcDir || './', { globs: this.include, ignore: this.exclude });
       } else {
-        entries = this.input.entries(this.srcDir || './');
+        entries = this.input.at(0).entries(this.srcDir || './');
       }
 
       entries = this._processEntries(entries);

--- a/tests/index.js
+++ b/tests/index.js
@@ -1167,5 +1167,39 @@ describe('broccoli-funnel', function() {
 
       expect(walkSync(outputPath)).to.eql(['lol/', 'lol/foo.js']);
     });
+
+    it('providing additional trees does not change matched files', async function() {
+      class FunnelSubclass extends Funnel.Funnel {
+        constructor(inputNode, options) {
+          super([inputNode, input.path('dir1/subdir1/subsubdir2')], options);
+
+          this._hasBuilt = false;
+        }
+
+        build() {
+          if (this._hasBuilt === false) {
+            if (!fs.existsSync(`${this.inputPaths[1]}/some.js`)) {
+              throw new Error('Could not find file!!!');
+            }
+            // set custom destDir to ensure our custom build code ran
+            this.destDir = 'lol';
+            this._hasBuilt = true;
+          }
+
+          return super.build();
+        }
+      }
+
+      let inputPath = input.path('lib/utils');
+      let node = new FunnelSubclass(inputPath, {
+        include: ['**/*.js'],
+      });
+      output = createBuilder(node);
+
+      await output.build();
+      let outputPath = output.path();
+
+      expect(walkSync(outputPath)).to.eql(['lol/', 'lol/foo.js']);
+    });
   });
 });


### PR DESCRIPTION
In a7ed4fa82a6492728cd48cbe3fb0b48c79d4c3ae we added support for passing additional trees to the constructor (to ensure that they can be ready to read in subclasses), but we didn't ensure that all internal usage of `this.input` was limited to the first tree passed. This didn't matter much for the simple symlink srcDir <-> destDir situation, but as soon as you use custom `include`/`exclude` globs (and we therefore have to walk all the files) we would trigger errors.

This fixes that oversight by ensuring that all usage of `this.input` is scoped to `this.input.at(0)`, and adds a previously failing test.
