### PR TITLE
perf: check existsSync before calling unlinkSync

### DIFF
--- a/index.js
+++ b/index.js
@@ -483,10 +483,15 @@ class Funnel extends Plugin {
       this.output.symlinkOrCopySync(sourcePath, relativePath);
     } catch (e) {
       this.output.mkdirSync(destDir, { recursive: true });
-      try {
-        this.output.unlinkSync(relativePath);
-      } catch (e) {
-        // swallow the error
+
+      // existsSync is fast, while unlinkSync is expensive,
+      // and extra expensive when it throws
+      if (this.output.existsSync(relativePath)) {
+        try {
+          this.output.unlinkSync(relativePath);
+        } catch (e) {
+          // swallow the error
+        }
       }
       this.output.symlinkOrCopySync(sourcePath, relativePath);
     }


### PR DESCRIPTION
`unlinkSync` is very expensive when it throws, which it will do if `existsSync` returns `false` for the path. In my large ember app this gets hit a lot. Note that almost all of the time spent in `unlinkSync` comes from error handling, which is only needed when `unlinkSync` would throw. Adding this guard shaves about 4 seconds off of the 21 seconds spent in _copy. I suspect there are more performance improvements to be made here.

These tests were done with node v16.16. The fs error handling behavior/perf might vary across node versions.

Before:
`unlinkSync` takes 4.9s of 21s in `_copy`
<img width="736" alt="Screenshot 2023-10-09 at 10 13 51 PM" src="https://github.com/broccolijs/broccoli-funnel/assets/20404/d5f1d98e-b5e8-4208-b3ee-848d31918b39">


After:
`unlinkSync` takes 0s of 17s in `_copy`
<img width="852" alt="Screenshot 2023-10-09 at 10 03 09 PM" src="https://github.com/broccolijs/broccoli-funnel/assets/20404/5533c25f-db2d-4e57-8260-5494efdc2b0e">
